### PR TITLE
Show mass of unnamed players

### DIFF
--- a/viewer.py
+++ b/viewer.py
@@ -43,7 +43,7 @@ class GameViewer(object):
         scale = self.game.view_w / 800
         if scale == 0:
             scale = 2
-         
+
         # handle events (user input)
         for event in pygame.event.get():
             if event.type == QUIT:
@@ -108,6 +108,7 @@ class GameViewer(object):
                 text_rect.centery = int((cell.y - cell.size)/scale - 5)
                 self.screen.blit(text, text_rect)
 
+            if cell.size > 20 and not cell.virus:
                 # render mass under cell
                 num = str(round(cell.size))
                 if self.render_special:
@@ -117,7 +118,7 @@ class GameViewer(object):
                 text_rect.centerx = int(cell.x/scale)
                 text_rect.centery = int((cell.y + cell.size)/scale + (self.font_size / 2))
                 self.screen.blit(text, text_rect)
-                
+
                 if self.render_special:
                     text = self.font.render(str(len(cell.watchers)), 0, color)
                     text_rect = text.get_rect()


### PR DESCRIPTION
The server doesn't seem to give a way to distinguish between a pellet and a player with no name, so I used a workarround. Player cell mass (including ejections) never goes  under 31, pellets aren't over 11, so 20 is a good compomise I think.