### PR TITLE
implemented workaround for the "rsv not implemented" issue

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -31,6 +31,7 @@ class Bot(object):
         self.has_sent_init = False
         self.last_sent_spawn = 0
         self.last_update = 0
+        self.n_updates = 0
 
         # cell information
         self.ids = []  # list of ids (to get cell, query id in all_cells)

--- a/session.py
+++ b/session.py
@@ -18,6 +18,8 @@ class Session(object):
         self.inbound = []
 
     def connect(self, host, port):
+        self.host = host
+        self.port = port
         if not self.is_connected():
             if type(port) == int:
                 port = str(port)
@@ -60,10 +62,14 @@ class Session(object):
             try:
                 if self.ws.connected:
                     data = self.ws.recv()
+                    #print("data : " + str(data))
                     self.inbound.append(data)
             except Exception as ex:
                 print('[session] run (' + str(self.ws.connected) + '): ' + str(ex))
-                return
+                print("disconnecting...")
+                self.ws.close()
+                self.inbound = []
+                print("disconnected, please wait for reconnection")
 
     def read(self):
         if self.is_connected():


### PR DESCRIPTION
When the "rsv not implemented" exception is raised, the session closes the websocket, and waits for the bot to reconnect it (can take a few seconds)